### PR TITLE
Fix issue #19: clamp() returns wrong value when out of range

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -34,8 +34,8 @@ function celsiusToFahrenheit(c) {
 }
 
 function clamp(value, min, max) {
-  if (value < min) return max;
-  if (value > max) return min;
+  if (value < min) return min;
+  if (value > max) return max;
   return value;
 }
 


### PR DESCRIPTION
## Fix
Automated fix for issue #19: clamp() returns wrong value when out of range

## Code Review
```
VERDICT: PASS
SUMMARY: Swapped the return values in `clamp()` so that out-of-range values below `min` return `min` and above `max` return `max`.
NOTES: None
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```

---
*Generated by AI agent*