### PR TITLE
Fix issue #: power() returns wrong result when exponent is 0

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -40,7 +40,7 @@ function clamp(value, min, max) {
 }
 
 function power(base, exp) {
-  if (exp === 0) return 0;
+  if (exp === 0) return 1;
   return Math.pow(base, exp);
 }
 


### PR DESCRIPTION
## Fix
Automated fix for issue #21: power() returns wrong result when exponent is 0

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Changed `power()` base case from `return 0` to `return 1` when `exp === 0`, correctly implementing the mathematical identity x⁰ = 1.
NOTES: The early return is now redundant since `Math.pow(base, 0)` already returns `1`, but it's harmless. No edge case concerns.
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```

---
*Generated by AI agent*