### PR TITLE
Fix issue #23: average() returns wrong result

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -46,7 +46,7 @@ function power(base, exp) {
 
 function average(numbers) {
   const sum = numbers.reduce((a, b) => a + b, 0);
-  return sum * numbers.length;
+  return sum / numbers.length;
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #23

## Fix
Automated fix for issue #23: average() returns wrong result

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Changed `average()` to divide `sum` by `numbers.length` instead of multiplying, which correctly computes the arithmetic mean.
NOTES: No guard for empty array — `numbers.length === 0` would return `NaN` due to division by zero. Acceptable if callers guarantee non-empty input, but worth noting.
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```
