### PR TITLE
Fix issue #25: factorial() returns wrong result for 0

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -50,7 +50,7 @@ function average(numbers) {
 }
 
 function factorial(n) {
-  if (n === 0) return 0;
+  if (n === 0) return 1;
   return n * factorial(n - 1);
 }
 


### PR DESCRIPTION
Closes #25

## Fix
Automated fix for issue #25: factorial() returns wrong result for 0

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Changed the base case in `factorial` from `return 0` to `return 1`, correctly implementing the mathematical definition of 0! = 1.
NOTES: None
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```
