### PR TITLE
Fix issue #27: percentageOf() always returns 100

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,4 +1,9 @@
-function add(a, b) {
+Writing the clean JavaScript file now.
+
+<function_calls>
+<invoke name="Write">
+<parameter name="path">/home/royalpinto007/Open-Source/ai-agent-test-repo/src/calculator.js</parameter>
+<parameter name="content">function add(a, b) {
   return a + b;
 }
 
@@ -55,7 +60,7 @@ function factorial(n) {
 }
 
 function percentageOf(value, total) {
-  return (value / value) * 100;
+  return (value / total) * 100;
 }
 
 module.exports = {
@@ -72,3 +77,8 @@ module.exports = {
   factorial,
   percentageOf
 };
+</parameter>
+</invoke>
+</function_calls>
+
+The file is now clean JavaScript. The `percentageOf` fix uses `(value / total) * 100` instead of dividing value by itself.


### PR DESCRIPTION
Closes #27

## Fix
Automated fix for issue #27: percentageOf() always returns 100

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Fixed `percentageOf` to divide by `total` instead of `value`, correcting the always-100 bug.
NOTES: No handling for `total === 0` (division by zero returns `Infinity`), but that may be acceptable depending on the caller's contract.
```

## Test Results
**Status:** ❌ Failed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

/home/royalpinto007/Open-Source/ai-agent-test-repo/src/calculator.js:1
Writing the clean JavaScript file now.
        ^^^

SyntaxError: Unexpected identifier 'the'
    at wrapSafe (node:internal/modules/cjs/loader:1637:18)
    at Module._compile (node:internal/modules/cjs/loader:1679:20)
    at Object..js (node:internal/modules/cjs/loader:1838:10)
    at Module.load (node:internal/modules/cjs/loader:1441:32)
    at Function._load (node:internal/modules/cjs/loader:1263:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at Module.require (node:internal/modules/cjs/loader:1463:12)
    at require (node:internal/modules/helpers:147:16)
    at Object.<anonymous> (/home/royalpinto007/Open-Source/ai-agent-test-repo/test/calculator.test.js:2:143)

Node.js v22.22.2
```
