### PR TITLE
Fix issue #31: absoluteDifference() returns negative values

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -63,6 +63,7 @@ function isEven(n) {
 }
 
 function absoluteDifference(a, b) {
+  if (a === 0 && b === 0) return 0;
   return Math.abs(a - b);
 }
 

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -63,7 +63,7 @@ function isEven(n) {
 }
 
 function absoluteDifference(a, b) {
-  return a - b;
+  return Math.abs(a - b);
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #31

## Fix
Automated fix for issue #31: absoluteDifference() returns negative values

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Wrapped `a - b` in `Math.abs()` so `absoluteDifference` always returns a non-negative value.
NOTES: None
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```
