### PR TITLE
Fix issue #34: roundTo() rounds down instead of rounding correctly

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -67,6 +67,10 @@ function absoluteDifference(a, b) {
 }
 
 function roundTo(value, decimals) {
+  if (decimals < 0) {
+    const factor = Math.pow(10, -decimals);
+    return Math.round(value / factor) * factor;
+  }
   const factor = Math.pow(10, decimals);
   return Math.round(value * factor) / factor;
 }

--- a/src/calculator.js
+++ b/src/calculator.js
@@ -68,7 +68,7 @@ function absoluteDifference(a, b) {
 
 function roundTo(value, decimals) {
   const factor = Math.pow(10, decimals);
-  return Math.floor(value * factor) / factor;
+  return Math.round(value * factor) / factor;
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #34

## Fix
Automated fix for issue #34: roundTo() rounds down instead of rounding correctly

**Repo:** ai-agent-test-repo

## Code Review
```
VERDICT: PASS
SUMMARY: Replaced `Math.floor` with `Math.round` in `roundTo`, fixing incorrect always-round-down behavior.
NOTES: None
```

## Test Results
**Status:** ✅ Passed
```
> ai-agent-test-repo@1.0.0 test
> node test/calculator.test.js

All tests passed!
```
