### PR TITLE
Add string input validation to calculator operations

### DIFF
--- a/src/calculator.js
+++ b/src/calculator.js
@@ -1,12 +1,22 @@
+function assertNumeric(label, v) {
+  if (typeof v !== 'number' || !Number.isFinite(v)) throw new TypeError(label + ' must be a finite numeric value, got ' + (typeof v === 'number' ? v : typeof v));
+}
+
 function add(a, b) {
+  assertNumeric('add: a', a);
+  assertNumeric('add: b', b);
   return a + b;
 }
 
 function subtract(a, b) {
+  assertNumeric('subtract: a', a);
+  assertNumeric('subtract: b', b);
   return a - b;
 }
 
 function multiply(a, b) {
+  assertNumeric('multiply: a', a);
+  assertNumeric('multiply: b', b);
   return a * b;
 }
 
@@ -39,7 +49,10 @@ function clamp(value, min, max) {
   return value;
 }
 
+// typeof alone cannot detect NaN (typeof NaN === 'number'), so Number.isFinite is required
 function power(base, exp) {
+  assertNumeric('power: base', base);
+  assertNumeric('power: exp', exp);
   if (exp === 0) return 1;
   return Math.pow(base, exp);
 }
@@ -49,7 +62,11 @@ function average(numbers) {
   return sum / numbers.length;
 }
 
+// factorial(-1) causes infinite recursion; guards are ordered type → integer → sign
 function factorial(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) throw new TypeError('factorial: n must be a finite number, got ' + typeof n);
+  if (!Number.isInteger(n)) throw new RangeError('factorial: n must be an integer, got ' + n);
+  if (n < 0) throw new RangeError('factorial: n must be non-negative, got ' + n);
   if (n === 0) return 1;
   return n * factorial(n - 1);
 }
@@ -75,6 +92,13 @@ function roundTo(value, decimals) {
   return Math.round(value * factor) / factor;
 }
 
+function divide(dividend, divisor) {
+  assertNumeric('divide: dividend', dividend);
+  assertNumeric('divide: divisor', divisor);
+  if (divisor === 0) throw new RangeError('divide: divisor must not be zero');
+  return dividend / divisor;
+}
+
 module.exports = {
   add,
   subtract,
@@ -90,5 +114,6 @@ module.exports = {
   percentageOf,
   isEven,
   absoluteDifference,
-  roundTo
+  roundTo,
+  divide
 };

--- a/test/calculator.test.js
+++ b/test/calculator.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { add, subtract, multiply, calculateDiscount, getArea, isPrime, celsiusToFahrenheit, clamp, power, average, factorial, percentageOf, isEven, absoluteDifference, roundTo } = require("../src/calculator");
+const { add, subtract, multiply, calculateDiscount, getArea, isPrime, celsiusToFahrenheit, clamp, power, average, factorial, percentageOf, isEven, absoluteDifference, roundTo, divide } = require("../src/calculator");
 
 assert.strictEqual(add(2, 3), 5);
 assert.strictEqual(subtract(5, 2), 3);
@@ -36,5 +36,104 @@ assert.strictEqual(absoluteDifference(5, 5), 0);
 assert.strictEqual(roundTo(1.456, 2), 1.46);
 assert.strictEqual(roundTo(1.454, 2), 1.45);
 assert.strictEqual(roundTo(2.5, 0), 3);
+assert.strictEqual(roundTo(123.456, -1), 120);
+assert.strictEqual(roundTo(123.456, -2), 100);
+assert.strictEqual(roundTo(150, -2), 200);
+assert.strictEqual(roundTo(99, -2), 100);
+assert.strictEqual(roundTo(0, -1), 0);
+assert.strictEqual(roundTo(-123.456, -1), -120);
+assert.strictEqual(roundTo(-123.456, -2), -100);
+assert.strictEqual(Number.isFinite(roundTo(-123.456, -1)), true);
+
+// power() validation — assert.throws with a class checks instanceof; regex checks message
+assert.throws(() => power(null, 2), TypeError);
+assert.throws(() => power(null, 2), /base/);
+assert.throws(() => power(2, undefined), TypeError);
+assert.throws(() => power(2, undefined), /exp/);
+assert.throws(() => power('abc', 3), TypeError);
+assert.throws(() => power('abc', 3), /base/);
+assert.throws(() => power(NaN, 2), TypeError);
+assert.throws(() => power(NaN, 2), /base/);
+assert.throws(() => power(2, NaN), TypeError);
+assert.throws(() => power(2, NaN), /exp/);
+assert.throws(() => power(Infinity, 2), TypeError);
+assert.throws(() => power(Infinity, 2), /base/);
+assert.throws(() => power(true, 2), TypeError);
+assert.throws(() => power(true, 2), /numeric/);
+assert.throws(() => power([], 2), TypeError);
+assert.throws(() => power([], 2), /numeric/);
+
+// factorial() validation
+assert.throws(() => factorial(-1), RangeError);
+assert.throws(() => factorial(-1), /non-negative/);
+assert.throws(() => factorial(-100), RangeError);
+assert.throws(() => factorial(-100), /non-negative/);
+assert.throws(() => factorial(1.5), RangeError);
+assert.throws(() => factorial(1.5), /integer/);
+assert.throws(() => factorial(0.9), RangeError);
+assert.throws(() => factorial(0.9), /integer/);
+assert.throws(() => factorial('abc'), TypeError);
+assert.throws(() => factorial(null), TypeError);
+assert.throws(() => factorial(Infinity), TypeError);
+
+// divide() happy path
+assert.strictEqual(typeof divide, 'function');
+assert.strictEqual(divide(10, 2), 5);
+assert.strictEqual(divide(7, 2), 3.5);
+assert.strictEqual(divide(-10, 2), -5);
+assert.strictEqual(divide(10, -2), -5);
+assert.strictEqual(divide(0, 5), 0);
+
+// divide() validation
+assert.throws(() => divide(10, 0), RangeError);
+assert.throws(() => divide(10, 0), /zero/);
+assert.throws(() => divide(0, 0), RangeError);
+assert.throws(() => divide(-5, 0), RangeError);
+assert.throws(() => divide(null, 2), TypeError);
+assert.throws(() => divide(null, 2), /dividend/);
+assert.throws(() => divide(10, 'x'), TypeError);
+assert.throws(() => divide(10, 'x'), /divisor/);
+assert.throws(() => divide(undefined, 2), TypeError);
+assert.throws(() => divide(undefined, 2), /dividend/);
+assert.throws(() => divide(true, 2), TypeError);
+assert.throws(() => divide(true, 2), /numeric/);
+assert.throws(() => divide([], 2), TypeError);
+assert.throws(() => divide([], 2), /numeric/);
+
+// add() validation
+assert.throws(() => add('a', 1), TypeError);
+assert.throws(() => add('a', 1), /numeric/);
+assert.throws(() => add(null, 1), TypeError);
+assert.throws(() => add(null, 1), /numeric/);
+assert.throws(() => add(true, 5), TypeError);
+assert.throws(() => add(true, 5), /numeric/);
+assert.throws(() => add([], 1), TypeError);
+assert.throws(() => add([], 1), /numeric/);
+assert.throws(() => add(1, 'b'), TypeError);
+assert.throws(() => add(1, 'b'), /numeric/);
+
+// subtract() validation
+assert.throws(() => subtract('a', 1), TypeError);
+assert.throws(() => subtract('a', 1), /numeric/);
+assert.throws(() => subtract(null, 1), TypeError);
+assert.throws(() => subtract(null, 1), /numeric/);
+assert.throws(() => subtract(true, 5), TypeError);
+assert.throws(() => subtract(true, 5), /numeric/);
+assert.throws(() => subtract([], 1), TypeError);
+assert.throws(() => subtract([], 1), /numeric/);
+assert.throws(() => subtract(1, 'b'), TypeError);
+assert.throws(() => subtract(1, 'b'), /numeric/);
+
+// multiply() validation
+assert.throws(() => multiply('a', 1), TypeError);
+assert.throws(() => multiply('a', 1), /numeric/);
+assert.throws(() => multiply(null, 1), TypeError);
+assert.throws(() => multiply(null, 1), /numeric/);
+assert.throws(() => multiply(true, 5), TypeError);
+assert.throws(() => multiply(true, 5), /numeric/);
+assert.throws(() => multiply([], 1), TypeError);
+assert.throws(() => multiply([], 1), /numeric/);
+assert.throws(() => multiply(1, 'b'), TypeError);
+assert.throws(() => multiply(1, 'b'), /numeric/);
 
 console.log("All tests passed!");


### PR DESCRIPTION
**Summary:** Adds input validation to `add`, `subtract`, and `multiply`, and hardens `power` and `divide` to also reject boolean inputs. A shared private `assertNumeric(label, v)` helper enforces `typeof v === 'number'` and `Number.isFinite(v)`, which correctly rejects strings, `null`, `undefined`, booleans (since `typeof true === 'boolean'`), and arrays. Error messages contain `"numeric"` per the acceptance criteria.

**Files changed:**
- `src/calculator.js` — added `assertNumeric` helper, applied to `add`/`subtract`/`multiply`/`power`/`divide`
- `test/calculator.test.js` — added TypeError coverage for `add`, `subtract`, `multiply`, and boolean/array cases for `power` and `divide`

**How to test:**
```
node test/calculator.test.js
```
All assertions should pass and print `All tests passed!`.

---

Closes #41